### PR TITLE
Massive performance improvements to touching block

### DIFF
--- a/scratch-js/Sprite.js
+++ b/scratch-js/Sprite.js
@@ -82,59 +82,11 @@ export default class Sprite {
     const matching = spr => spr.constructor.name === sprName
     const matchingSprites = sprites.filter(matching)
 
-    const renderer = this._project.renderer
-
-    const ownBox = renderer.getBoundingBox(this)
-    const ownStage = renderer.createStage().getContext('2d')
-    renderer.renderSprite(this, ownStage)
-
     for (let i = 0; i < matchingSprites.length; i++) {
       const spr = matchingSprites[i]
-      const box = this._project.renderer.getBoundingBox(spr)
 
-      if (ownBox.right <= box.left) continue
-      if (ownBox.left >= box.right) continue
-      if (ownBox.bottom <= box.top) continue
-      if (ownBox.top >= box.bottom) continue
-
-      if (fast) return true
-
-      const stage = renderer.createStage().getContext('2d')
-      renderer.renderSprite(spr, stage)
-
-      let scanRegion = {
-        left: Math.max(ownBox.left, box.left),
-        right: Math.min(ownBox.right, box.right),
-        top: Math.max(ownBox.top, box.top),
-        bottom: Math.min(ownBox.bottom, box.bottom)
-      }
-      scanRegion.width = scanRegion.right - scanRegion.left
-      scanRegion.height = scanRegion.bottom - scanRegion.top
-
-      const getScanImageData = ctx => ctx.getImageData(
-        scanRegion.left,
-        scanRegion.top,
-        scanRegion.width,
-        scanRegion.height
-      )
-
-      const imgData = getScanImageData(stage)
-      const ownImgData = getScanImageData(ownStage)
-
-      const getPoint = (x, y, imgData) => {
-        const start = 4 * (y * imgData.width + x)
-        return imgData.data.slice(start, start + 4)
-      }
-
-      for (let x = 0; x < scanRegion.width; x++) {
-        for (let y = 0; y < scanRegion.height; y++) {
-          if (getPoint(x, y, imgData)[3] > 0) {
-            if (getPoint(x, y, ownImgData)[3] > 0) {
-              return true
-            }
-          }
-        }
-      }
+      const collision = this._project.renderer.checkSpriteCollision(this, spr, fast)
+      if (collision) return true
     }
 
     return false


### PR DESCRIPTION
This is fun! The touching block just made some serious performance gains.

Previously, in the "platform physics" demo, a single frame could take upwards of `60ms` when walking uphill. Now, the worst-case scenario takes about `11ms` to complete (on my machine). That's an 82% improvement!

The new version implements a lot of ideas from the [phosphorous source code](https://github.com/nathan/phosphorus/blob/915ecc1185654e7bb3279faa3ec3457852064088/phosphorus.js#L1641-L1680). Thanks @nathan! Especially useful was the `source-in` [composite operation](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/globalCompositeOperation). It allows comparing alpha values without doing any extra math.