### PR TITLE
Optimize pen line drawing + other WebGL improvements

### DIFF
--- a/scratch-js/Color.mjs
+++ b/scratch-js/Color.mjs
@@ -204,13 +204,13 @@ export default class Color {
   }
 
   toRGBA() {
-    const rgb = hsvToRGB(this.h, this.s, this.v);
-    return [rgb.r, rgb.g, rgb.b, this.a * 255];
+    const rgb = hsvToRGB(this._h, this._s, this._v);
+    return [rgb.r, rgb.g, rgb.b, this._a * 255];
   }
 
   toRGBANormalized() {
-    const rgb = hsvToRGB(this.h, this.s, this.v);
-    return [rgb.r / 255, rgb.g / 255, rgb.b / 255, this.a];
+    const rgb = hsvToRGB(this._h, this._s, this._v);
+    return [rgb.r / 255, rgb.g / 255, rgb.b / 255, this._a];
   }
 
   toString() {

--- a/scratch-js/Renderer.mjs
+++ b/scratch-js/Renderer.mjs
@@ -143,7 +143,11 @@ export default class Renderer {
 
       this._currentShader = shader;
       this._updateStageSize();
+
+      return true;
     }
+
+    return false;
   }
 
   _setFramebuffer(framebufferInfo) {

--- a/scratch-js/renderer/VectorSkin.mjs
+++ b/scratch-js/renderer/VectorSkin.mjs
@@ -32,8 +32,14 @@ export default class VectorSkin extends Skin {
     let width = image.naturalWidth * scale;
     let height = image.naturalHeight * scale;
 
-    width = Math.min(width, this._maxTextureSize);
-    height = Math.min(height, this._maxTextureSize);
+    width = Math.round(Math.min(width, this._maxTextureSize));
+    height = Math.round(Math.min(height, this._maxTextureSize));
+
+    // Prevent IndexSizeErrors if the image is too small to render
+    if (width === 0 || height === 0) {
+      this._mipmaps.set(mipLevel, null);
+      return;
+    }
 
     canvas.width = width;
     canvas.height = height;


### PR DESCRIPTION
- Only set pen uniforms if they need to be set
  - This should improve pen performance a fair bit. I'm still looking into other ways to improve it but this is a good start.
- Optimize `Color.toRGBA[Normalized]` by not using the `Color`'s getter properties
- Prevent an `IndexSizeError` in `VectorSkin` by not trying to draw an SVG if its size is 0