### PR TITLE
Add counter property to stage, defaulting to zero

### DIFF
--- a/scratch-js/Sprite.mjs
+++ b/scratch-js/Sprite.mjs
@@ -519,6 +519,6 @@ export class Stage extends SpriteBase {
     this.name = "Stage";
 
     // For obsolete counter blocks.
-    this.counter = 0;
+    this.__counter = 0;
   }
 }

--- a/scratch-js/Sprite.mjs
+++ b/scratch-js/Sprite.mjs
@@ -517,5 +517,8 @@ export class Stage extends SpriteBase {
     });
 
     this.name = "Stage";
+
+    // For obsolete counter blocks.
+    this.counter = 0;
   }
 }


### PR DESCRIPTION
This must be merged before PullJosh/sb-edit#12.

It's a little silly that we need to add a new property only for these obscure blocks, but at least this is the only case of that being necessary - we *do* need to store that global value somewhere (perfect for the stage), and all the other blocks to be added are just no-ops.