### PR TITLE
Renderer fixes

### DIFF
--- a/scratch-js/Costume.mjs
+++ b/scratch-js/Costume.mjs
@@ -7,6 +7,10 @@ export default class Costume {
     this.img.crossOrigin = "Anonymous";
     this.img.src = this.url;
 
+    // TODO: this is super janky, but fixing this fully requires restructuring costume loading
+    this.isBitmap = !this.url.match(/\.svg/);
+    this.resolution = this.isBitmap ? 2 : 1;
+
     this.center = center;
   }
 

--- a/scratch-js/Renderer.mjs
+++ b/scratch-js/Renderer.mjs
@@ -326,6 +326,9 @@ export default class Renderer {
   _renderSkin(skin, drawMode, matrix, scale, effects, beforeRendering) {
     const gl = this.gl;
 
+    const skinTexture = skin.getTexture(scale * this._screenSpaceScale);
+    if (!skinTexture) return;
+
     let effectBitmask = 0;
     if (effects) effectBitmask = effects._bitmask;
     const shader = this._shaderManager.getShader(drawMode, effectBitmask);
@@ -345,8 +348,6 @@ export default class Renderer {
     }
 
     if (typeof beforeRendering === "function") beforeRendering(skin, shader);
-
-    const skinTexture = skin.getTexture(scale * this._screenSpaceScale);
 
     gl.bindTexture(gl.TEXTURE_2D, skinTexture);
     // All textures are bound to texture unit 0, so that's where the texture sampler should point

--- a/scratch-js/Renderer.mjs
+++ b/scratch-js/Renderer.mjs
@@ -379,8 +379,22 @@ export default class Renderer {
       const spriteScale = spr.size / 100;
       Matrix.scale(m, m, spriteScale, spriteScale);
     }
-    Matrix.translate(m, m, -spr.costume.center.x, -spr.costume.center.y);
-    Matrix.scale(m, m, spr.costume.width, spr.costume.height);
+
+    const scalingFactor = 1 / spr.costume.resolution;
+    // Rotation centers are in non-Scratch space (positive y-values = down),
+    // but these transforms are in Scratch space (negative y-values = down).
+    Matrix.translate(
+      m,
+      m,
+      -spr.costume.center.x * scalingFactor,
+      (spr.costume.center.y - spr.costume.height) * scalingFactor
+    );
+    Matrix.scale(
+      m,
+      m,
+      spr.costume.width * scalingFactor,
+      spr.costume.height * scalingFactor
+    );
 
     return m;
   }

--- a/scratch-js/renderer/SkinCache.mjs
+++ b/scratch-js/renderer/SkinCache.mjs
@@ -43,11 +43,10 @@ export default class SkinCache {
       let skin;
 
       if (obj instanceof Costume) {
-        // TODO: there's gotta be a better way to tell if an image is an SVG
-        if (obj.img.src.endsWith(".svg")) {
-          skin = new VectorSkin(this._renderer, obj.img);
-        } else {
+        if (obj.isBitmap) {
           skin = new BitmapSkin(this._renderer, obj.img);
+        } else {
+          skin = new VectorSkin(this._renderer, obj.img);
         }
       } else {
         // If it's not a costume, assume it's a speech bubble.


### PR DESCRIPTION
- Return early if a skin's texture doesn't exist
  - This prevents WebGL warnings from spamming the console.
- Handle double-resolution costumes
  - I've moved the code for telling whether a costume is a bitmap costume to the `Costume` class. Costumes also now have a `resolution` property which is 2 for bitmaps and 1 for vectors. This matches Scratch 3.0, in which all bitmap costumes are double-resolution (single-resolution ones are upscaled during importing).
- Fix costume rotation centers' y-axes
  - These were flipped. Turns out, they're not in "Scratch-space".