### PR TITLE
Merge pull request #49 from towerofnix/sound-objects

### DIFF
--- a/scratch-js/Project.mjs
+++ b/scratch-js/Project.mjs
@@ -24,8 +24,6 @@ export default class Project {
 
     this.answer = null;
 
-    this.playingSounds = [];
-
     this.step();
   }
 
@@ -154,25 +152,6 @@ export default class Project {
 
   get spritesAndStage() {
     return [...this.spritesAndClones, this.stage];
-  }
-
-  _stopSound(sound) {
-    if (sound.hasStarted) {
-      sound.audio.pause();
-    } else {
-      // Audio can't be paused because it hasn't started yet
-      // (audio.play() is async; can't pause until play starts)
-      sound.audio.addEventListener("playing", () => {
-        // Stop for real ASAP
-        sound.audio.pause();
-      });
-    }
-
-    // Remove from playingSounds
-    const index = this.playingSounds.findIndex(s => s === sound);
-    if (index > -1) {
-      this.playingSounds.splice(index, 1);
-    }
   }
 
   stopAllSounds() {

--- a/scratch-js/Project.mjs
+++ b/scratch-js/Project.mjs
@@ -156,28 +156,6 @@ export default class Project {
     return [...this.spritesAndClones, this.stage];
   }
 
-  playSound(url) {
-    return new Promise((resolve, reject) => {
-      const audio = new Audio(url);
-
-      const sound = { audio, hasStarted: false };
-
-      const soundEnd = () => {
-        this._stopSound(sound);
-        resolve();
-      };
-      audio.addEventListener("ended", soundEnd);
-      audio.addEventListener("pause", soundEnd);
-      audio.addEventListener("error", reject);
-
-      this.playingSounds.push(sound);
-
-      audio.play().then(() => {
-        sound.hasStarted = true;
-      });
-    });
-  }
-
   _stopSound(sound) {
     if (sound.hasStarted) {
       sound.audio.pause();
@@ -198,9 +176,8 @@ export default class Project {
   }
 
   stopAllSounds() {
-    const playingSoundsCopy = this.playingSounds.slice();
-    for (let i = 0; i < playingSoundsCopy.length; i++) {
-      this._stopSound(playingSoundsCopy[i]);
+    for (const target of this.spritesAndStage) {
+      target.stopAllOfMySounds();
     }
   }
 

--- a/scratch-js/Sound.mjs
+++ b/scratch-js/Sound.mjs
@@ -1,0 +1,52 @@
+export default class Sound {
+  constructor(name, url) {
+    this.name = name;
+    this.url = url;
+
+    this.audio = new Audio();
+    this.audio.crossOrigin = "Anonymous";
+    this.audio.src = this.url;
+  }
+
+  get duration() {
+    return this.audio.duration;
+  }
+
+  start() {
+    this.audio.currentTime = 0;
+
+    if (this._markDone) {
+      this._markDone();
+    }
+
+    return this.audio.play();
+  }
+
+  *playUntilDone() {
+    let playing = true;
+
+    this.audio.addEventListener("ended", () => {
+      playing = false;
+      delete this._markDone;
+    });
+
+    this.start();
+
+    // Set _markDone after calling start(), because if there's any existing value for _markDone, start() will call that
+    // (so that the playUntilDone which set it will end).
+    this._markDone = () => {
+      playing = false;
+      delete this._markDone;
+    };
+
+    while (playing) yield;
+  }
+
+  stop() {
+    if (this._markDone) {
+      this._markDone();
+    }
+
+    this.audio.pause();
+  }
+}

--- a/scratch-js/Sprite.mjs
+++ b/scratch-js/Sprite.mjs
@@ -59,6 +59,7 @@ class SpriteBase {
 
     this.triggers = [];
     this.costumes = [];
+    this.sounds = [];
 
     this.effects = new _EffectMap();
 
@@ -205,17 +206,38 @@ class SpriteBase {
     this._project.restartTimer();
   }
 
-  *playSound(url) {
-    let playing = true;
-    this._project.playSound(url).then(() => {
-      playing = false;
-    });
+  startSound(soundName) {
+    const sound = this.getSound(soundName);
+    if (sound) {
+      return sound.start();
+    } else {
+      return Promise.resolve();
+    }
+  }
 
-    while (playing) yield;
+  *playSoundUntilDone(soundName) {
+    const sound = this.getSound(soundName);
+    if (sound) {
+      yield* sound.playUntilDone();
+    }
+  }
+
+  getSound(soundName) {
+    if (typeof soundName === "number") {
+      return this.sounds[((soundName - 1) % this.sounds.length) + 1];
+    } else {
+      return this.sounds.find(s => s.name === soundName);
+    }
   }
 
   stopAllSounds() {
     this._project.stopAllSounds();
+  }
+
+  stopAllOfMySounds() {
+    for (const sound of this.sounds) {
+      sound.stop();
+    }
   }
 
   broadcast(name) {
@@ -305,6 +327,7 @@ export class Sprite extends SpriteBase {
       trigger => new Trigger(trigger.trigger, trigger.options, trigger._script)
     );
     clone.costumes = this.costumes;
+    clone.sounds = this.sounds;
     clone._vars = Object.assign({}, this._vars);
 
     clone._speechBubble = {

--- a/scratch-js/index.mjs
+++ b/scratch-js/index.mjs
@@ -3,5 +3,6 @@ import { Sprite, Stage } from "./Sprite.mjs";
 import Trigger from "./Trigger.mjs";
 import Costume from "./Costume.mjs";
 import Color from "./Color.mjs";
+import Sound from "./Sound.mjs";
 
-export { Project, Sprite, Stage, Trigger, Costume, Color };
+export { Project, Sprite, Stage, Trigger, Costume, Color, Sound };


### PR DESCRIPTION
...and match Scratch behavior with regards to restarting sounds, dealing with yields, etc.

Alongside sb-edit#21, this implements playing sounds from exported Scratch 3.0 projects. (No WAV support yet though - that should be implemented separately.)

Test it out with this project: https://scratch.mit.edu/projects/360677530/