### PR TITLE
Add MIT license text, and me to contributors

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,9 @@
+Copyright (c) 2020, Josh Pullen <hello@joshuapullen.com>
+Copyright (c) 2020, adroitwhiz <adroitwhiz@protonmail.com>
+Copyright (c) 2020, Florrie Haero Miller <towerofnix@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "author": "Josh Pullen <hello@joshuapullen.com> (https://joshuapullen.com/)",
   "contributors": [
-    "adroitwhiz <adroitwhiz@protonmail.com> (https://github.com/adroitwhiz)"
+    "adroitwhiz <adroitwhiz@protonmail.com> (https://github.com/adroitwhiz)",
+    "Florrie Haero Miller <towerofnix@gmail.com> (https://github.com/towerofnix)"
   ],
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
`package.json` already stated scratch-js was licensed under MIT; this PR adds an actual license file so that we 1) state specific copyrights (equal to code contributors, sorted oldest-contribution at top) and 2) have any legal bearings, as a result. It's also just good code practice, of course! :P