### PR TITLE
Fix getting sound by index

### DIFF
--- a/scratch-js/Sprite.mjs
+++ b/scratch-js/Sprite.mjs
@@ -224,7 +224,7 @@ class SpriteBase {
 
   getSound(soundName) {
     if (typeof soundName === "number") {
-      return this.sounds[((soundName - 1) % this.sounds.length) + 1];
+      return this.sounds[(soundName - 1) % this.sounds.length];
     } else {
       return this.sounds.find(s => s.name === soundName);
     }


### PR DESCRIPTION
When accessing an array, we want a 0-indexed value, not 1-indexed.

(This code was copied from the costume-switching code; that code expects a 1-indexed value, so, without testing, it was carried over here. Sorry!)

Test it out with this project: https://scratch.mit.edu/projects/360176981/