### PR TITLE
Support ADPCM audio

### DIFF
--- a/scratch-js/Sound.mjs
+++ b/scratch-js/Sound.mjs
@@ -1,39 +1,95 @@
+import decodeADPCMAudio, { isWavData } from "./lib/decode-adpcm-audio.mjs";
+
 export default class Sound {
   constructor(name, url) {
     this.name = name;
     this.url = url;
 
-    this.audio = new Audio();
-    this.audio.crossOrigin = "Anonymous";
-    this.audio.src = this.url;
+    this.audioBuffer = null;
+    this.node = null;
+    this.source = null;
+
+    // TODO: Remove this line; initiate downloads from somewhere else instead.
+    this.downloadMyAudioBuffer();
   }
 
   get duration() {
-    return this.audio.duration;
+    return this.audioBuffer.duration;
   }
 
-  start() {
-    this.audio.currentTime = 0;
+  *start() {
+    let started = false;
+    let isLatestCallToStart = true;
 
     if (this._markDone) {
       this._markDone();
     }
 
-    return this.audio.play();
+    if (this.audioBuffer) {
+      this.playMyAudioBuffer();
+      started = true;
+    } else {
+      // It's possible that start() will be called again before this start() has
+      // successfully started the sound (i.e. because it was waiting for the
+      // audio buffer to download). If that's the case, _doneDownloading will
+      // already exist. We never want to return from start() before the sound has
+      // begun playing, but in the case of playUntilDone(), only the latest call
+      // should wait for the sound to finish playing; also, we only need to run
+      // playMyAudioBuffer once. To meet all these conditions, and also to avoid
+      // implementing some kind of addEventListener-esque system, we implement
+      // a simple "listener chain" here. Every time we set call start(), we keep
+      // track of the previous value of doneDownloading, and replace it with a new
+      // function. When this function is called directly as a result of the download
+      // finishing, it will call, if existent, the previous value of doneDownloading
+      // with a flag indicating it is being called from a more recent call to
+      // start(). That function will in turn do the same for its saved previous
+      // value, and so on, until all the previous values of doneDownloading have
+      // been called. Thus, all previous calls of start() will then finish,
+      // returning their value of isLatestCallToStart: false, indicating that if the
+      // call came from playUntilDone(), that playUntilDone should not wait for the
+      // sound to finish playing. Of course, the latest call returns true, and so
+      // the containing playUntilDone() (if present) knows to wait.
+      const oldDoneDownloading = this._doneDownloading;
+      this._doneDownloading = fromMoreRecentCall => {
+        if (fromMoreRecentCall) {
+          isLatestCallToStart = false;
+        } else {
+          this.playMyAudioBuffer();
+          started = true;
+          delete this._doneDownloading;
+        }
+        if (oldDoneDownloading) {
+          oldDoneDownloading(true);
+        }
+      };
+    }
+
+    while (!started && isLatestCallToStart) yield;
+
+    return isLatestCallToStart;
   }
 
   *playUntilDone() {
     let playing = true;
 
-    this.audio.addEventListener("ended", () => {
+    const isLatestCallToStart = yield* this.start();
+
+    this.source.addEventListener("ended", () => {
       playing = false;
       delete this._markDone;
     });
 
-    this.start();
+    // If there was another call to start() since ours, don't wait for the
+    // sound to finish before returning.
+    if (!isLatestCallToStart) {
+      return;
+    }
 
-    // Set _markDone after calling start(), because if there's any existing value for _markDone, start() will call that
-    // (so that the playUntilDone which set it will end).
+    // Set _markDone after calling start(), because start() will call the existing
+    // value of _markDone if it's already set. It does this because playUntilDone()
+    // is meant to be interrupted if another start() is ran while it's playing.
+    // Of course, we don't want *this* playUntilDone() to be treated as though it
+    // were interrupted when we call start(), so setting _markDone comes after.
     this._markDone = () => {
       playing = false;
       delete this._markDone;
@@ -47,6 +103,62 @@ export default class Sound {
       this._markDone();
     }
 
-    this.audio.pause();
+    if (this.node) {
+      this.node.disconnect();
+      this.node = null;
+    }
+  }
+
+  downloadMyAudioBuffer() {
+    Sound.setupAudioContext();
+    return fetch(this.url)
+      .then(body => body.arrayBuffer())
+      .then(arrayBuffer => {
+        if (isWavData(arrayBuffer)) {
+          return decodeADPCMAudio(arrayBuffer, Sound.audioContext);
+        } else {
+          return new Promise((resolve, reject) => {
+            Sound.audioContext.decodeAudioData(arrayBuffer, resolve, reject);
+          });
+        }
+      })
+      .then(audioBuffer => {
+        this.audioBuffer = audioBuffer;
+        if (this._doneDownloading) {
+          this._doneDownloading();
+        }
+        return audioBuffer;
+      });
+  }
+
+  playMyAudioBuffer() {
+    Sound.setupAudioContext();
+
+    if (!this.node) {
+      this.node = Sound.audioContext.createGain();
+      this.node.connect(Sound.audioContext.destination);
+    }
+
+    if (this.source) {
+      this.source.disconnect();
+    }
+    this.source = Sound.audioContext.createBufferSource();
+    this.source.buffer = this.audioBuffer;
+    this.source.connect(this.node);
+
+    this.source.start(Sound.audioContext.currentTime);
+  }
+
+  static setupAudioContext() {
+    // note: this === the Sound class here!
+    if (!this.audioContext) {
+      const AudioContext = window.AudioContext || window.webkitAudioContext;
+      this.audioContext = new AudioContext();
+    }
+  }
+
+  static decodeADPCMAudio(audioBuffer) {
+    this.setupAudioContext();
+    return decodeADPCMAudio(audioBuffer, this.audioContext);
   }
 }

--- a/scratch-js/Sprite.mjs
+++ b/scratch-js/Sprite.mjs
@@ -206,12 +206,10 @@ class SpriteBase {
     this._project.restartTimer();
   }
 
-  startSound(soundName) {
+  *startSound(soundName) {
     const sound = this.getSound(soundName);
     if (sound) {
-      return sound.start();
-    } else {
-      return Promise.resolve();
+      yield* sound.start();
     }
   }
 

--- a/scratch-js/lib/decode-adpcm-audio.mjs
+++ b/scratch-js/lib/decode-adpcm-audio.mjs
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  *
- * Copyright (c) 2013-2019 Nathan Dinsmore and Adroitwhiz
+ * Copyright (c) 2013-2019 Truman Kilen, Nathan Dinsmore, and Adroitwhiz
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/scratch-js/lib/decode-adpcm-audio.mjs
+++ b/scratch-js/lib/decode-adpcm-audio.mjs
@@ -1,0 +1,122 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013-2019 Nathan Dinsmore and Adroitwhiz
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+// prettier-ignore
+const ADPCM_STEPS = [
+  7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 19, 21, 23, 25, 28, 31, 34, 37, 41, 45, 50, 55, 60, 66, 73, 80, 88, 97, 107,
+  118, 130, 143, 157, 173, 190, 209, 230, 253, 279, 307, 337, 371, 408, 449, 494, 544, 598, 658, 724, 796, 876, 963,
+  1060, 1166, 1282, 1411, 1552, 1707, 1878, 2066, 2272, 2499, 2749, 3024, 3327, 3660, 4026, 4428, 4871, 5358, 5894,
+  6484, 7132, 7845, 8630, 9493, 10442, 11487, 12635, 13899, 15289, 16818, 18500, 20350, 22385, 24623, 27086, 29794,
+  32767
+];
+
+const ADPCM_INDEX = [-1, -1, -1, -1, 2, 4, 6, 8, -1, -1, -1, -1, 2, 4, 6, 8];
+
+export default function decodeADPCMAudio(ab, audioContext) {
+  const dv = new DataView(ab);
+  // WAV magic number
+  if (dv.getUint32(0) !== 0x52494646 || dv.getUint32(8) !== 0x57415645) {
+    return Promise.reject(new Error("Unrecognized audio format"));
+  }
+
+  const blocks = {};
+  const l = dv.byteLength - 8;
+  let i = 12;
+  while (i < l) {
+    blocks[
+      String.fromCharCode(
+        dv.getUint8(i),
+        dv.getUint8(i + 1),
+        dv.getUint8(i + 2),
+        dv.getUint8(i + 3)
+      )
+    ] = i;
+    i += 8 + dv.getUint32(i + 4, true);
+  }
+
+  const format = dv.getUint16(20, true);
+  const sampleRate = dv.getUint32(24, true);
+
+  if (format === 17) {
+    const samplesPerBlock = dv.getUint16(38, true);
+    const blockSize = (samplesPerBlock - 1) / 2 + 4;
+
+    const frameCount = dv.getUint32(blocks.fact + 8, true);
+
+    const buffer = audioContext.createBuffer(1, frameCount, sampleRate);
+    const channel = buffer.getChannelData(0);
+
+    let sample;
+    let index = 0;
+    let step, code, delta;
+    let lastByte = -1;
+
+    const offset = blocks.data + 8;
+    let i = offset;
+    let j = 0;
+    while (true) { // eslint-disable-line
+      if ((i - offset) % blockSize === 0 && lastByte < 0) {
+        if (i >= dv.byteLength) break;
+        sample = dv.getInt16(i, true);
+        i += 2;
+        index = dv.getUint8(i);
+        i += 1;
+        i++;
+        if (index > 88) index = 88;
+        channel[j++] = sample / 32767;
+      } else {
+        if (lastByte < 0) {
+          if (i >= dv.byteLength) break;
+          lastByte = dv.getUint8(i);
+          i += 1;
+          code = lastByte & 0xf;
+        } else {
+          code = (lastByte >> 4) & 0xf;
+          lastByte = -1;
+        }
+        step = ADPCM_STEPS[index];
+        delta = 0;
+        if (code & 4) delta += step;
+        if (code & 2) delta += step >> 1;
+        if (code & 1) delta += step >> 2;
+        delta += step >> 3;
+        index += ADPCM_INDEX[code];
+        if (index > 88) index = 88;
+        if (index < 0) index = 0;
+        sample += code & 8 ? -delta : delta;
+        if (sample > 32767) sample = 32767;
+        if (sample < -32768) sample = -32768;
+        channel[j++] = sample / 32768;
+      }
+    }
+    return Promise.resolve(buffer);
+  }
+  return Promise.reject(new Error(`Unrecognized WAV format ${format}`));
+}
+
+export function isWavData(arrayBuffer) {
+  const dataView = new DataView(arrayBuffer);
+  return (
+    dataView.getUint32(0) !== 0x52494646 && dataView.getUint32(8) !== 0x57415645
+  );
+}

--- a/scratch-js/lib/decode-adpcm-audio.mjs
+++ b/scratch-js/lib/decode-adpcm-audio.mjs
@@ -117,6 +117,12 @@ export default function decodeADPCMAudio(ab, audioContext) {
 export function isWavData(arrayBuffer) {
   const dataView = new DataView(arrayBuffer);
   return (
-    dataView.getUint32(0) !== 0x52494646 && dataView.getUint32(8) !== 0x57415645
+    dataView.getUint32(0) === 0x52494646 && dataView.getUint32(8) === 0x57415645
   );
+}
+
+export function isADPCMData(arrayBuffer) {
+  const dataView = new DataView(arrayBuffer);
+  const format = dataView.getUint16(20, true);
+  return isWavData(arrayBuffer) && format === 17;
 }


### PR DESCRIPTION
This PR implements ADPCM audio (sounds based on WAV files), completing support for playing sounds from imported Scratch projects.

Things of note:

- We reuse a single audio context for all sounds; it's stored on the `Sound` constructor itself. (It could be put in a variable local to that module, but I figured I'd expose the value just in case we want to reference it outside of that file later.)
- The ADPCM decoder is [a library file](https://github.com/adroitwhiz/bismuth/blob/master/src/bismuth/io/decode-adpcm-audio.js) taken from @adroitwhiz's Bismuth project. It's been slightly tweaked here to match our code style and export a few extra utility functions. I've included Bismuth's [LICENSE](https://github.com/adroitwhiz/bismuth/blob/master/LICENSE) in the header of that file, crediting Nathan, who wrote the original code for Phosphorus.
  - It's probably worth taking a look at #50 since that formalizes the license/copyright of scratch-js, but I don't believe it's necessary to merge that before this, because we've got Bismuth's license embedded in the code taken from it.
- We only run the ADPCM decoder on the audio format which it supports, i.e. format = 17. Any other type of data is passed to the browser's builtin audio decoder, which supports MP3, etc, as well as PCM audio (format = 1). Thus, I believe with this PR we cover every format that Scratch projects contain.
- The event emitter logic is sort of clunky. It does work though! :P You can test that particular chunk of the code with this project: https://scratch.mit.edu/projects/360677530/

I've tested this with a variety of projects and they all play every sound as expected - mp3, PCM, ADPCM alike.