### PR TITLE
Implement audio effects

### DIFF
--- a/scratch-js/Project.mjs
+++ b/scratch-js/Project.mjs
@@ -104,6 +104,7 @@ export default class Project {
 
       for (const sprite of this.spritesAndStage) {
         sprite.effects.clear();
+        sprite.clearAudioEffects();
       }
     }
 

--- a/scratch-js/Project.mjs
+++ b/scratch-js/Project.mjs
@@ -104,7 +104,7 @@ export default class Project {
 
       for (const sprite of this.spritesAndStage) {
         sprite.effects.clear();
-        sprite.clearAudioEffects();
+        sprite.audioEffects.clear();
       }
     }
 

--- a/scratch-js/Sound.mjs
+++ b/scratch-js/Sound.mjs
@@ -6,8 +6,8 @@ export default class Sound {
     this.url = url;
 
     this.audioBuffer = null;
-    this.node = null;
     this.source = null;
+    this.playbackRate = 1;
 
     // TODO: Remove this line; initiate downloads from somewhere else instead.
     this.downloadMyAudioBuffer();
@@ -29,26 +29,27 @@ export default class Sound {
       this.playMyAudioBuffer();
       started = true;
     } else {
-      // It's possible that start() will be called again before this start() has
-      // successfully started the sound (i.e. because it was waiting for the
-      // audio buffer to download). If that's the case, _doneDownloading will
-      // already exist. We never want to return from start() before the sound has
-      // begun playing, but in the case of playUntilDone(), only the latest call
-      // should wait for the sound to finish playing; also, we only need to run
-      // playMyAudioBuffer once. To meet all these conditions, and also to avoid
-      // implementing some kind of addEventListener-esque system, we implement
-      // a simple "listener chain" here. Every time we set call start(), we keep
-      // track of the previous value of doneDownloading, and replace it with a new
-      // function. When this function is called directly as a result of the download
-      // finishing, it will call, if existent, the previous value of doneDownloading
-      // with a flag indicating it is being called from a more recent call to
-      // start(). That function will in turn do the same for its saved previous
-      // value, and so on, until all the previous values of doneDownloading have
-      // been called. Thus, all previous calls of start() will then finish,
-      // returning their value of isLatestCallToStart: false, indicating that if the
-      // call came from playUntilDone(), that playUntilDone should not wait for the
-      // sound to finish playing. Of course, the latest call returns true, and so
-      // the containing playUntilDone() (if present) knows to wait.
+      // It's possible that start() will be called again before this start()
+      // has successfully started the sound (i.e. because it was waiting for
+      // the audio buffer to download). If that's the case, _doneDownloading
+      // will already exist. We never want to return from start() before the
+      // sound has begun playing, but in the case of playUntilDone(), only the
+      // latest call should wait for the sound to finish playing; also, we only
+      // need to run playMyAudioBuffer once. To meet all these conditions, and
+      // also to avoid implementing some kind of addEventListener-esque system,
+      // we implement a simple "listener chain" here. Every time we set call
+      // start(), we keep track of the previous value of doneDownloading, and
+      // replace it with a new function. When this function is called directly
+      // as a result of the download finishing, it will call, if existent, the
+      // previous value of doneDownloading with a flag indicating it is being
+      // called from a more recent call to start(). That function will in turn
+      // do the same for its saved previous value, and so on, until all the
+      // previous values of doneDownloading have been called. Thus, all
+      // previous calls of start() will then finish, returning their value of
+      // isLatestCallToStart: false, indicating that if the call came from
+      // playUntilDone(), that playUntilDone should not wait for the sound to
+      // finish playing. Of course, the latest call returns true, and so the
+      // containing playUntilDone() (if present) knows to wait.
       const oldDoneDownloading = this._doneDownloading;
       this._doneDownloading = fromMoreRecentCall => {
         if (fromMoreRecentCall) {
@@ -109,9 +110,9 @@ export default class Sound {
       this._markDone();
     }
 
-    if (this.node) {
-      this.node.disconnect();
-      this.node = null;
+    if (this.source) {
+      this.source.disconnect();
+      this.source = null;
     }
   }
 
@@ -151,23 +152,44 @@ export default class Sound {
 
     Sound.setupAudioContext();
 
-    if (!this.node) {
-      this.node = Sound.audioContext.createGain();
-      this.node.connect(Sound.audioContext.destination);
-    }
-
     if (this.source) {
       this.source.disconnect();
     }
+
     this.source = Sound.audioContext.createBufferSource();
     this.source.buffer = this.audioBuffer;
-    this.source.connect(this.node);
+    this.source.playbackRate.value = this.playbackRate;
+
+    if (this.target) {
+      this.source.connect(this.target);
+    }
 
     this.source.start(Sound.audioContext.currentTime);
   }
 
+  connect(target) {
+    if (target !== this.target) {
+      this.target = target;
+      if (this.source) {
+        this.source.disconnect();
+        this.source.connect(this.target);
+      }
+    }
+  }
+
+  setPlaybackRate(value) {
+    this.playbackRate = value;
+    if (this.source) {
+      this.source.playbackRate.value = value;
+    }
+  }
+
+  isConnectedTo(target) {
+    return this.target === target;
+  }
+
   static setupAudioContext() {
-    // note: this === the Sound class here!
+    // Note: "this" refers to the Sound class in static functions.
     if (!this.audioContext) {
       const AudioContext = window.AudioContext || window.webkitAudioContext;
       this.audioContext = new AudioContext();
@@ -179,3 +201,422 @@ export default class Sound {
     return decodeADPCMAudio(audioBuffer, this.audioContext);
   }
 }
+
+export class EffectChain {
+  // The code in this class is functionally comparable to the class of the same
+  // name in the scratch-audio library, but is completely rewritten and follows
+  // somewhat different logic. Still, the class exists on the same principle:
+  // a portable way to store the effect chain, independent of the audio sources
+  // it affects.
+
+  constructor(config) {
+    Sound.setupAudioContext();
+
+    const {getNonPatchSoundList} = config;
+    this.config = config;
+
+    this.inputNode = Sound.audioContext.createGain();
+
+    // This is a mapping of an effect's name to an object containing all the
+    // nodes which are of use to that effect: always an {input, output} pair,
+    // as well as any other nodes of use to that effect. The values here are
+    // filled in by an effect descriptor's makeNodes() function, and may
+    // contain duplicate copies of the same node within a particular effect's
+    // object, when that's of use to make the logic clearer (e.g. when there's
+    // no distinction between the input and output node, or referring to the
+    // output node by a more specific name).
+    this.effectNodes = {};
+
+    this.resetToInitial();
+
+    this.getNonPatchSoundList = getNonPatchSoundList;
+  }
+
+  resetToInitial() {
+    // Note: some effects won't be reset by this function, except for when they
+    // are set for the first time (i.e. when the EffectChain is instantiated).
+    // Look for the "reset: false" flag in the effect descriptor list.
+
+    const initials = EffectChain.getInitialEffectValues();
+    if (this.effectValues) {
+      for (const [name, initialValue] of Object.entries(EffectChain.getInitialEffectValues())) {
+        if (EffectChain.getEffectDescriptor(name).reset !== false) {
+          this.setEffectValue(name, initialValue);
+        }
+      }
+    } else {
+      this.effectValues = initials;
+    }
+  }
+
+  updateAudioEffect(name) {
+    const descriptor = EffectChain.getEffectDescriptor(name);
+
+    if (!descriptor) {
+      return;
+    }
+
+    // Technically, no code in this function depends on the audio context being
+    // available; we call it here so that the function descriptors don't need
+    // to do so themselves. (Just as technically, we'd never need to run
+    // setupAudioContext now; it's run right when EffectChain is constructed,
+    // so that we have access to creating the input Gain node. But I prefer to
+    // avoid depending on the internals of functions defined outside of
+    // whatever function I'm currently working on, so that the code is more
+    // dependable if generally unrelated code changes in the future.)
+    Sound.setupAudioContext();
+
+    // updateAudioEffect doesn't take a value - it only reflects the existing
+    // value in the actual effects applied to nodes and sounds!
+    const value = this.effectValues[name];
+
+    if (descriptor.isPatch) {
+      // Here, we search for the next and previous effects in the chain
+      // who have existent nodes. This means we'll skip non-patch effects as
+      // well as effects are set to their initial value.
+
+      let next = descriptor;
+      do {
+        next = EffectChain.getNextEffectDescriptor(next.name);
+      } while (next && !this.effectNodes[next.name]);
+
+      let previous = descriptor;
+      do {
+        previous = EffectChain.getPreviousEffectDescriptor(previous.name);
+      } while (previous && !this.effectNodes[previous.name]);
+
+      // If we have previous and next values available, they'll currently be
+      // the corresponding descriptors. But we only ever need to access the
+      // nodes which correspond to those descriptor's names, so we replace them
+      // with the actual objects containing the effect's nodes here to simplify
+      // later code.
+
+      if (next) {
+        next = this.effectNodes[next.name];
+      }
+
+      if (previous) {
+        next = this.effectNodes[previous.name];
+      }
+
+      // If there is no preceding or following effect which has existent nodes,
+      // we'll make the variables reference the target input and target nodes
+      // of the EffectChain - i.e, the two ends of the chain, as far as this
+      // class is concerned. (Note that while the input node will always be
+      // present, because it's defined right on the EffectChain, it's possible
+      // that there won't be any target node, leaving the value for "next"
+      // still null.)
+      //
+      // We do need to keep to the structure that effectNodes contains, though.
+      // When we access the previous node (or the EffectChain's input node, in
+      // this case), we'll be making a connection with its output; likewise,
+      // when we're accessing the next node (or the EffectChain's target),
+      // we'll be connecting something to its input. That's reflected in the
+      // values here.
+
+      if (!previous) {
+        previous = {output: this.inputNode};
+      }
+
+      if (!next && this.target) {
+        next = {input: this.target};
+      }
+
+      // "Patch" effects are applied by sending audio data through an ordered
+      // series - i.e, a chain - of WebAudio nodes. All effects have an input
+      // node and an output node; for simple effects, these may actually be the
+      // same node. (Take a look at the volume effect, which uses a single Gain
+      // node as both its input and output.) Other effects are more complex.
+      // The code in this block controls the actual chaining behavior of
+      // EffectChain, assuring that all effects form a clean chain.
+      let nodes = this.effectNodes[descriptor.name];
+      if (!nodes && value !== descriptor.initial) {
+        nodes = descriptor.makeNodes();
+        this.effectNodes[descriptor.name] = nodes;
+
+        // Connect the previous effect, or, if there is none, the EffectChain
+        // input, to this effect. Also disconnect it from whatever it was
+        // previously connected to, so we aren't sending data more than one
+        // place at a time - that would mess with the chain.
+        previous.output.disconnect();
+        previous.output.connect(nodes.input);
+
+        // Connect this effect to the next effect, or, if there is none,
+        // the EffectChain target.
+        if (next) {
+          nodes.output.connect(next.input);
+        }
+      }
+
+      if (value === descriptor.initial) {
+        // If we're setting to the initial value, disconnect and discard the
+        // effect's nodes. It's not necessary to keep nodes that don't cause
+        // an effect in the chain. (We don't need to run the set() behavior
+        // specified on the effect descriptor, since we're disconnecting and
+        // discarding the nodes - the only values that function has access to.)
+        if (nodes) {
+          // There's no need to define custom disposal behavior per effect,
+          // since it's always a matter of simply disconnecting every node.
+          // The disconnect() method of a WebAudio node won't error if it's
+          // already had all its connections removed, but we avoid redundant
+          // calls here anyway.
+          for (const node of new Set(Object.values(nodes))) {
+            node.disconnect();
+          }
+
+          // We also need to establish a connection between the adjacent nodes
+          // (which may be the EffectChain's input node and target node, if
+          // there aren't any adjacent effect nodes).
+          if (next) {
+            previous.output.connect(next.input);
+          }
+
+          // Finally, we discard the object which holds the effect's nodes.
+          // We aren't going to be using it anymore, and we need it gone so
+          // that we recreate the nodes and correctly position them back in
+          // the chain, if we use this effect again later.
+          delete this.effectNodes[name];
+        }
+      } else {
+        descriptor.set(value, nodes);
+      }
+    } else {
+      // Non-"patch" effects operate directly on Sound objects, accessing
+      // APIs provided by that class. The actual sound list is provided by the
+      // caller of EffectChain.
+      for (const sound of this.getNonPatchSoundList()) {
+        descriptor.set(value, sound);
+      }
+    }
+  }
+
+  connect(target) {
+    this.target = target;
+
+    // All the code here is basically the same as what's written in
+    // updateAudioEffect above; specific to this function, we want to
+    // disconnect the final output in the chain - which may be the input
+    // node - and then connect it to the newly specified target.
+
+    let last = EffectChain.getLastEffectDescriptor();
+    do {
+      last = EffectChain.getPreviousEffectDescriptor(last.name);
+    } while (last && !this.effectNodes[last.name]);
+
+    if (last) {
+      last = this.effectNodes[last.name];
+    } else {
+      last = {output: this.inputNode};
+    }
+
+    last.output.disconnect();
+    last.output.connect(target);
+  }
+
+  setEffectValue(name, value) {
+    value = Number(value);
+    if (name in this.effectValues && !isNaN(value) && value !== this.effectValues[name]) {
+      this.effectValues[name] = value;
+      this.clampEffectValue(name);
+      this.updateAudioEffect(name);
+    }
+  }
+
+  changeEffectValue(name, value) {
+    value = Number(value);
+    if (name in this.effectValues && !isNaN(value) && value !== 0) {
+      this.effectValues[name] += value;
+      this.clampEffectValue(name);
+      this.updateAudioEffect(name);
+    }
+  }
+
+  clampEffectValue(name) {
+    // Not all effects are clamped (pitch, for example); it's also possible to
+    // specify only a minimum or maximum bound, instead of both.
+    const descriptor = EffectChain.getEffectDescriptor(name);
+    let value = this.effectValues[name];
+    if ("minimum" in descriptor && value < descriptor.minimum) {
+      value = descriptor.minimum;
+    } else if ("maximum" in descriptor && value > descriptor.maximum) {
+      value = descriptor.maximum;
+    }
+    this.effectValues[name] = value;
+  }
+
+  getEffectValue(name) {
+    return this.effectValues[name] || 0;
+  }
+
+  clone(newConfig) {
+    const newEffectChain = new EffectChain(Object.assign({}, this.config, newConfig));
+
+    for (const [name, value] of Object.entries(this.effectValues)) {
+      const descriptor = EffectChain.getEffectDescriptor(name);
+      if (!descriptor.resetOnClone) {
+        newEffectChain.setEffectValue(name, value);
+      }
+    }
+
+    newEffectChain.connect(this.target);
+
+    return newEffectChain;
+  }
+
+  applyToSound(sound) {
+    sound.connect(this.inputNode);
+
+    for (const [name, value] of Object.entries(this.effectValues)) {
+      const descriptor = EffectChain.getEffectDescriptor(name);
+      if (!descriptor.isPatch) {
+        descriptor.set(value, sound);
+      }
+    }
+  }
+
+  isTargetOf(sound) {
+    return sound.isConnectedTo(this.inputNode);
+  }
+
+  static getInitialEffectValues() {
+    // This would be an excellent place to use Object.fromEntries, but that
+    // function has been implemented in only the latest of a few modern
+    // browsers. :P
+    const initials = {};
+    for (const {name, initial} of this.effectDescriptors) {
+      initials[name] = initial;
+    }
+    return initials;
+  }
+
+  static getEffectDescriptor(name) {
+    return this.effectDescriptors.find(descriptor => descriptor.name === name);
+  }
+
+  static getFirstEffectDescriptor() {
+    return this.effectDescriptors[0];
+  }
+
+  static getLastEffectDescriptor() {
+    return this.effectDescriptors[this.effectDescriptors.length - 1];
+  }
+
+  static getNextEffectDescriptor(name) {
+    // .find() provides three values to its passed function: the value of the
+    // current item, that item's index, and the array on which .find() is
+    // operating. In this case, we're only concerned with the index.
+    // For each item in the list, besides the first, we check if the item
+    // before it matches the name we were given. By initially shifting all the
+    // descriptors using slice(1), the index of any item in the shifted list
+    // corresponds to the previous item in the original list. Thus, if that
+    // previous item matches the provided name, by definition, we'll have found
+    // the item which comes after it.
+    return this.effectDescriptors.slice(1).find((_, i) => this.effectDescriptors[i].name === name);
+  }
+
+  static getPreviousEffectDescriptor(name) {
+    // This function's a little simpler, since it doesn't involve shifting the
+    // list. We still use slice(), but this time simply to cut off the last
+    // item; that item will never come before any other, after all. We search
+    // the list for the item whose following item matches the provided name,
+    // using the more typical [i + 1] way of accessing an adjacent item.
+    // (In getNextEffectDescriptor(), we don't need to offset the index like
+    // that, because the shift already lines up the index as we need it.)
+    return this.effectDescriptors.slice(0, -1).find((_, i) => this.effectDescriptors[i + 1].name === name);
+  }
+}
+
+// These are constant values which can be affected to tweak the way effects
+// are applied. They match the values used in Scratch 3.0.
+EffectChain.decayDuration = 0.025;
+EffectChain.decayWait = 0.05;
+
+// Instead of creating a basic Effect class and then implementing a subclass
+// for each effect type, we use a simplified object-descriptor style.
+// The makeNodes() function returns an object which is passed on to set(), so
+// that effects are able to access a variety of nodes (or other values, if
+// necessary) required to execute the desired effect.
+//
+// The code in makeNodes as well as the general definition for each effect is
+// all graciously based on LLK's scratch-audio library.
+//
+// The initial value of an effect should always be the value at which the
+// sound is not affected at all - i.e, it would be the same if the effect
+// nodes were completely disconnected from the chain or otherwise had never
+// been applied. This allows for clean discarding of effect nodes when returned
+// to the initial value.
+//
+// The order of this array matches AudioEngine's effects list in scratch-audio.
+// Earlier in the list is closer to the EffectChain input node; later is closer
+// to its target (output). Note that a non-"patch" effect's position in the
+// array has no bearing on effect behavior, since it isn't part of the chain
+// system.
+//
+// Note that this descriptor list is fairly easy to build on, if we'd like to
+// add more audio effects in the future. (Scratch used to have more, but they
+// were removed - see commit ff6cd4a - because they depended on an external
+// library and were too processor-intensive to support on some devices.)
+EffectChain.effectDescriptors = [
+  {
+    name: "pan",
+    initial: 0,
+    minimum: -100,
+    maximum: 100,
+    isPatch: true,
+    makeNodes() {
+      const aCtx = Sound.audioContext;
+      const input = aCtx.createGain();
+      const leftGain = aCtx.createGain();
+      const rightGain = aCtx.createGain();
+      const channelMerger = aCtx.createChannelMerger(2);
+      const output = channelMerger;
+      input.connect(leftGain);
+      input.connect(rightGain);
+      leftGain.connect(channelMerger, 0, 0);
+      rightGain.connect(channelMerger, 0, 1);
+      return {input, output, leftGain, rightGain, channelMerger};
+    },
+    set(value, {input, output, leftGain, rightGain}) {
+      const p = (value + 100) / 200;
+      const leftVal = Math.cos(p * Math.PI / 2);
+      const rightVal = Math.sin(p * Math.PI / 2);
+      const {currentTime} = Sound.audioContext;
+      const {decayWait, decayDuration} = EffectChain;
+      leftGain.gain.setTargetAtTime(leftVal, currentTime + decayWait, decayDuration);
+      rightGain.gain.setTargetAtTime(rightVal, currentTime + decayWait, decayDuration);
+    }
+  },
+  {
+    name: "pitch",
+    initial: 0,
+    isPatch: false,
+    set(value, sound) {
+      const interval = value / 10;
+      const ratio = Math.pow(2, (interval / 12));
+      sound.setPlaybackRate(ratio);
+    }
+  },
+  {
+    name: "volume",
+    initial: 100,
+    minimum: 0,
+    maximum: 100,
+    resetOnStart: false,
+    resetOnClone: true,
+    isPatch: true,
+    makeNodes() {
+      const node = Sound.audioContext.createGain();
+      return {
+        input: node,
+        output: node,
+        node
+      };
+    },
+    set(value, {node}) {
+      node.gain.linearRampToValueAtTime(
+        value / 100,
+        Sound.audioContext.currentTime + EffectChain.decayDuration
+      );
+    }
+  }
+];

--- a/scratch-js/Sound.mjs
+++ b/scratch-js/Sound.mjs
@@ -620,3 +620,26 @@ EffectChain.effectDescriptors = [
     }
   }
 ];
+
+export class AudioEffectMap {
+  // This class provides a simple interface for setting and getting audio
+  // effects stored on an EffectChain, similar to EffectMap (that class being
+  // for graphic effects). It takes an EffectChain and automatically generates
+  // properties according to the names of the effect descriptors, acting with
+  // the EffectChain's API when accessed.
+
+  constructor(effectChain) {
+    this.effectChain = effectChain;
+
+    for (const {name} of EffectChain.effectDescriptors) {
+      Object.defineProperty(this, name, {
+        get: () => effectChain.getEffectValue(name),
+        set: value => effectChain.setEffectValue(name, value)
+      });
+    }
+  }
+
+  clear() {
+    this.effectChain.resetToInitial();
+  }
+}

--- a/scratch-js/Sound.mjs
+++ b/scratch-js/Sound.mjs
@@ -212,7 +212,7 @@ export class EffectChain {
   // it affects.
 
   constructor(config) {
-    const {getNonPatchSoundList} = config;
+    const { getNonPatchSoundList } = config;
     this.config = config;
 
     this.inputNode = Sound.audioContext.createGain();
@@ -239,7 +239,9 @@ export class EffectChain {
 
     const initials = EffectChain.getInitialEffectValues();
     if (this.effectValues) {
-      for (const [name, initialValue] of Object.entries(EffectChain.getInitialEffectValues())) {
+      for (const [name, initialValue] of Object.entries(
+        EffectChain.getInitialEffectValues()
+      )) {
         if (EffectChain.getEffectDescriptor(name).reset !== false) {
           this.setEffectValue(name, initialValue);
         }
@@ -305,11 +307,11 @@ export class EffectChain {
       // values here.
 
       if (!previous) {
-        previous = {output: this.inputNode};
+        previous = { output: this.inputNode };
       }
 
       if (!next && this.target) {
-        next = {input: this.target};
+        next = { input: this.target };
       }
 
       // "Patch" effects are applied by sending audio data through an ordered
@@ -396,7 +398,7 @@ export class EffectChain {
     if (last) {
       last = this.effectNodes[last.name];
     } else {
-      last = {output: this.inputNode};
+      last = { output: this.inputNode };
     }
 
     last.output.disconnect();
@@ -405,7 +407,11 @@ export class EffectChain {
 
   setEffectValue(name, value) {
     value = Number(value);
-    if (name in this.effectValues && !isNaN(value) && value !== this.effectValues[name]) {
+    if (
+      name in this.effectValues &&
+      !isNaN(value) &&
+      value !== this.effectValues[name]
+    ) {
       this.effectValues[name] = value;
       this.clampEffectValue(name);
       this.updateAudioEffect(name);
@@ -439,7 +445,9 @@ export class EffectChain {
   }
 
   clone(newConfig) {
-    const newEffectChain = new EffectChain(Object.assign({}, this.config, newConfig));
+    const newEffectChain = new EffectChain(
+      Object.assign({}, this.config, newConfig)
+    );
 
     for (const [name, value] of Object.entries(this.effectValues)) {
       const descriptor = EffectChain.getEffectDescriptor(name);
@@ -473,7 +481,7 @@ export class EffectChain {
     // function has been implemented in only the latest of a few modern
     // browsers. :P
     const initials = {};
-    for (const {name, initial} of this.effectDescriptors) {
+    for (const { name, initial } of this.effectDescriptors) {
       initials[name] = initial;
     }
     return initials;
@@ -501,7 +509,9 @@ export class EffectChain {
     // corresponds to the previous item in the original list. Thus, if that
     // previous item matches the provided name, by definition, we'll have found
     // the item which comes after it.
-    return this.effectDescriptors.slice(1).find((_, i) => this.effectDescriptors[i].name === name);
+    return this.effectDescriptors
+      .slice(1)
+      .find((_, i) => this.effectDescriptors[i].name === name);
   }
 
   static getPreviousEffectDescriptor(name) {
@@ -512,7 +522,9 @@ export class EffectChain {
     // using the more typical [i + 1] way of accessing an adjacent item.
     // (In getNextEffectDescriptor(), we don't need to offset the index like
     // that, because the shift already lines up the index as we need it.)
-    return this.effectDescriptors.slice(0, -1).find((_, i) => this.effectDescriptors[i + 1].name === name);
+    return this.effectDescriptors
+      .slice(0, -1)
+      .find((_, i) => this.effectDescriptors[i + 1].name === name);
   }
 }
 
@@ -564,16 +576,24 @@ EffectChain.effectDescriptors = [
       input.connect(rightGain);
       leftGain.connect(channelMerger, 0, 0);
       rightGain.connect(channelMerger, 0, 1);
-      return {input, output, leftGain, rightGain, channelMerger};
+      return { input, output, leftGain, rightGain, channelMerger };
     },
-    set(value, {input, output, leftGain, rightGain}) {
+    set(value, { input, output, leftGain, rightGain }) {
       const p = (value + 100) / 200;
-      const leftVal = Math.cos(p * Math.PI / 2);
-      const rightVal = Math.sin(p * Math.PI / 2);
-      const {currentTime} = Sound.audioContext;
-      const {decayWait, decayDuration} = EffectChain;
-      leftGain.gain.setTargetAtTime(leftVal, currentTime + decayWait, decayDuration);
-      rightGain.gain.setTargetAtTime(rightVal, currentTime + decayWait, decayDuration);
+      const leftVal = Math.cos((p * Math.PI) / 2);
+      const rightVal = Math.sin((p * Math.PI) / 2);
+      const { currentTime } = Sound.audioContext;
+      const { decayWait, decayDuration } = EffectChain;
+      leftGain.gain.setTargetAtTime(
+        leftVal,
+        currentTime + decayWait,
+        decayDuration
+      );
+      rightGain.gain.setTargetAtTime(
+        rightVal,
+        currentTime + decayWait,
+        decayDuration
+      );
     }
   },
   {
@@ -582,7 +602,7 @@ EffectChain.effectDescriptors = [
     isPatch: false,
     set(value, sound) {
       const interval = value / 10;
-      const ratio = Math.pow(2, (interval / 12));
+      const ratio = Math.pow(2, interval / 12);
       sound.setPlaybackRate(ratio);
     }
   },
@@ -602,7 +622,7 @@ EffectChain.effectDescriptors = [
         node
       };
     },
-    set(value, {node}) {
+    set(value, { node }) {
       node.gain.linearRampToValueAtTime(
         value / 100,
         Sound.audioContext.currentTime + EffectChain.decayDuration
@@ -621,7 +641,7 @@ export class AudioEffectMap {
   constructor(effectChain) {
     this.effectChain = effectChain;
 
-    for (const {name} of EffectChain.effectDescriptors) {
+    for (const { name } of EffectChain.effectDescriptors) {
       Object.defineProperty(this, name, {
         get: () => effectChain.getEffectValue(name),
         set: value => effectChain.setEffectValue(name, value)

--- a/scratch-js/Sprite.mjs
+++ b/scratch-js/Sprite.mjs
@@ -62,7 +62,6 @@ class SpriteBase {
     this.costumes = [];
     this.sounds = [];
 
-    Sound.setupAudioContext();
     this.effectChain = new EffectChain({
       getNonPatchSoundList: this.getSoundsPlayedByMe.bind(this)
     });

--- a/scratch-js/Sprite.mjs
+++ b/scratch-js/Sprite.mjs
@@ -1,6 +1,6 @@
 import Color from "./Color.mjs";
 import Trigger from "./Trigger.mjs";
-import Sound, { EffectChain } from "./Sound.mjs";
+import Sound, { EffectChain, AudioEffectMap } from "./Sound.mjs";
 
 import effectNames from "./renderer/effectNames.mjs";
 // This is a wrapper to allow the enabled effects in a sprite to be used as a Map key.
@@ -62,13 +62,14 @@ class SpriteBase {
     this.costumes = [];
     this.sounds = [];
 
-    this.effects = new _EffectMap();
-
     Sound.setupAudioContext();
     this.effectChain = new EffectChain({
       getNonPatchSoundList: this.getSoundsPlayedByMe.bind(this)
     });
     this.effectChain.connect(Sound.audioContext.destination);
+
+    this.effects = new _EffectMap();
+    this.audioEffects = new AudioEffectMap(this.effectChain);
 
     this._vars = vars;
   }
@@ -242,22 +243,6 @@ class SpriteBase {
     }
   }
 
-  setAudioEffect(name, value) {
-    this.effectChain.setEffectValue(name, value);
-  }
-
-  changeAudioEffect(name, value) {
-    this.effectChain.changeEffectValue(name, value);
-  }
-
-  getAudioEffect(name) {
-    return this.effectChain.getEffectValue(name);
-  }
-
-  clearAudioEffects() {
-    this.effectChain.resetToInitial();
-  }
-
   stopAllSounds() {
     this._project.stopAllSounds();
   }
@@ -375,6 +360,9 @@ export class Sprite extends SpriteBase {
     clone.effectChain = original.effectChain.clone({
       getNonPatchSoundList: clone.getSoundsPlayedByMe.bind(clone)
     });
+
+    // Make a new audioEffects interface which acts on the cloned effect chain.
+    clone.audioEffects = new AudioEffectMap(clone.effectChain);
 
     clone.clones = [];
     clone.parent = this;

--- a/scratch-js/lib/decode-adpcm-audio.mjs
+++ b/scratch-js/lib/decode-adpcm-audio.mjs
@@ -74,7 +74,8 @@ export default function decodeADPCMAudio(ab, audioContext) {
     const offset = blocks.data + 8;
     let i = offset;
     let j = 0;
-    while (true) { // eslint-disable-line
+    // eslint-disable-next-line
+    while (true) {
       if ((i - offset) % blockSize === 0 && lastByte < 0) {
         if (i >= dv.byteLength) break;
         sample = dv.getInt16(i, true);


### PR DESCRIPTION
**This PR is based on #52.**
View https://github.com/towerofnix/scratch-js/compare/adpcm-audio...audio-effects for a diff between the two branches.

This pull request adds support for audio effects to scratch-js, matching Scratch 3.0's behavior to the best of my research.

The big addition is a new `EffectChain` class (an additional export from the `Sound.mjs` file). It's used to keep track of and apply any audio effects. Effect descriptors (defined at the end of that file) tell exactly how effects should behave, providing code which either creates and modifies its own WebAudio nodes or interacts with individual Sound objects through their APIs to apply an effect.

An EffectChain acts independently of its container and the WebAudio output; it's up to the container to build connections between the EffectChain and its source and output. In our code, we place a single EffectChain in each instance of a sprite; as in 3.0, effect values are shared across all sounds in a sprite/clone.

Because sound objects themselves are shared across all instances of a sprite (i.e. the original and any clones), we need to connect them to the correct EffectChain at the time they are started. There's a new API to handle all that (it re-applies effects which operate on sound objects too).

As for all the behavior within EffectChain - that's largely documented within the code! Have a look. Please feel encouraged to ask if anything's confusing - I've commented most spaces but there may be a few concepts I forgot to explain or didn't do so clearly enough. :)

I've shared a variety of demo projects in testing this; here's the full list:

- [Audio effects demo](https://scratch.mit.edu/projects/363195646/)
- [Pan to sides demo](https://scratch.mit.edu/projects/363490328/)
- [Clone audio effect inheritance demo (volume/non-patch)](https://scratch.mit.edu/projects/363510018/)
- [Clone audio effect inheritance demo (pan)](https://scratch.mit.edu/projects/363849475/)
- [Pitch back-and-forth demo](https://scratch.mit.edu/projects/363879213/)

There are specific details as to what they test in the project descriptions. Definitely try the first in the list, since it's a basic test that confirms all the effects work in conjunction in the first place!