### PR TITLE
Only lint .mjs files

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "scratch-js/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "lint": "eslint 'scratch-js/**.mjs'"
+    "lint": "eslint \"./scratch-js/**.mjs\""
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "scratch-js/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "lint": "eslint 'scratch-js/**'"
+    "lint": "eslint 'scratch-js/**.mjs'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
It appears that `scratch-js/index.css`, added as part of the ask/answer implementation, is causing ESLint to fail--it is trying to lint it. This PR ensures that ESLint is only run on `.mjs` files.