### PR TITLE
Remove _layerOrder and just store sprites in-order

### DIFF
--- a/src/Project.ts
+++ b/src/Project.ts
@@ -137,7 +137,9 @@ export default class Project {
     triggerMatches: (tr: Trigger, target: Sprite | Stage) => boolean
   ): TriggerWithTarget[] {
     const matchingTriggers: TriggerWithTarget[] = [];
-    for (const target of this.targets) {
+    // Iterate over targets in top-down order, as Scratch does
+    for (let i = this.targets.length - 1; i >= 0; i--) {
+      const target = this.targets[i];
       const matchingTargetTriggers = target.triggers.filter((tr) =>
         triggerMatches(tr, target)
       );

--- a/src/Project.ts
+++ b/src/Project.ts
@@ -230,6 +230,10 @@ export default class Project {
       for (const target of this.targets) {
         target.effects.clear();
         target.audioEffects.clear();
+        if (target instanceof Sprite) {
+          // The original sprite will always be first in the list. All other clones just got deleted.
+          target.andClones().length = 1;
+        }
       }
     }
 

--- a/src/Project.ts
+++ b/src/Project.ts
@@ -278,8 +278,12 @@ export default class Project {
     const index = this.targets.indexOf(sprite);
     if (index === -1) return;
 
-    this.targets.splice(index, 1);
-    filterArrayInPlace(this.runningTriggers, ({ target }) => target !== sprite);
+    const instances = new Set<Sprite | Stage>(sprite.andClones());
+    filterArrayInPlace(this.targets, (target) => !instances.has(target));
+    filterArrayInPlace(
+      this.runningTriggers,
+      ({ target }) => !instances.has(target)
+    );
   }
 
   public changeSpriteLayer(

--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -298,37 +298,33 @@ export default class Renderer {
         (filter && !filter(layer))
       );
 
-    // Stage
-    if (shouldIncludeLayer(this.project.stage)) {
-      this.renderSprite(this.project.stage, options);
-    }
+    this.project.forEachTarget((target) => {
+      // TODO: just make a `visible` getter for Stage to avoid this rigmarole
+      const visible = "visible" in target ? target.visible : true;
 
-    // Pen layer
-    if (shouldIncludeLayer(this._penSkin)) {
-      const penMatrix = Matrix.create();
-      Matrix.scale(
-        penMatrix,
-        penMatrix,
-        this._penSkin.width,
-        -this._penSkin.height
-      );
-      Matrix.translate(penMatrix, penMatrix, -0.5, -0.5);
-
-      this._renderSkin(
-        this._penSkin,
-        options.drawMode ?? ShaderManager.DrawModes.DEFAULT,
-        penMatrix,
-        1 /* scale */
-      );
-    }
-
-    // Sprites + clones
-    for (const sprite of this.project.spritesAndClones) {
-      // Stage doesn't have "visible" defined, so check if it's strictly false
-      if (shouldIncludeLayer(sprite) && sprite.visible !== false) {
-        this.renderSprite(sprite, options);
+      if (shouldIncludeLayer(target) && visible) {
+        this.renderSprite(target, options);
       }
-    }
+
+      // Draw the pen layer in front of the stage
+      if (target instanceof Stage && shouldIncludeLayer(this._penSkin)) {
+        const penMatrix = Matrix.create();
+        Matrix.scale(
+          penMatrix,
+          penMatrix,
+          this._penSkin.width,
+          -this._penSkin.height
+        );
+        Matrix.translate(penMatrix, penMatrix, -0.5, -0.5);
+
+        this._renderSkin(
+          this._penSkin,
+          options.drawMode ?? ShaderManager.DrawModes.DEFAULT,
+          penMatrix,
+          1 /* scale */
+        );
+      }
+    });
   }
 
   private _updateStageSize(): void {

--- a/src/lib/filter-array-in-place.ts
+++ b/src/lib/filter-array-in-place.ts
@@ -1,0 +1,19 @@
+/**
+ * Filter an array in-place.
+ * @param arr The array to filter in place.
+ * @param predicate Predicate function called for each item to decide whether it should remain in the array (`true` if it should stay, `false` if it should go).
+ */
+export default function filterArrayInPlace<T>(
+  arr: T[],
+  predicate: (item: T) => boolean
+): void {
+  let nextKeptIndex = 0;
+  for (let i = 0; i < arr.length; i++) {
+    const item = arr[i];
+    if (predicate(item)) {
+      arr[nextKeptIndex] = item;
+      nextKeptIndex++;
+    }
+  }
+  arr.length = nextKeptIndex;
+}


### PR DESCRIPTION
Depends on #207.

This gets rid of the `clones` hierarchy and `_layerOrder` property, and stores every rendered target (sprite, stage, or clone) in one array kept in layer order. Clones now refer directly to the "original" sprite instead of their parent.

While this *does* require some more management of that array, it means we don't have to:
- Maintain the `_layerOrder` property
- Construct and sort a bunch of new arrays every time we want to loop through all the rendered targets (slow)
- Traverse upwards through the clone hierarchy to find the "original" sprite

Starting triggers is also done in top-down order now (reverse layer order), which matches how Scratch does it.